### PR TITLE
Update actions to current version

### DIFF
--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: Renato66/auto-label@v2.2.0
+      - uses: Renato66/auto-label@v2.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           labels-not-allowed: '["Stale","Pendente de informações","Falta de informações"]'

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -7,10 +7,10 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Esta vaga encontra-se há um bom tempo sem novas interações. Se ainda estiver aberta, faça um comentário, caso contrario, a fecharemos automaticamente em 5 dias.'
+        stale-issue-message: 'Esta vaga encontra-se há um bom tempo sem novas interações. Se ainda estiver aberta, faça um comentário, caso contrario, a fecharemos automaticamente em 30 dias.'
         days-before-stale: 60
         days-before-close: 30
         ascending: true


### PR DESCRIPTION
Update the two GitHub actions to their current version
- [actions/stale](https://github.com/actions/stale) from v3 to v8
- [Renato66/auto-label](https://github.com/Renato66/auto-label) from v2.2.0 to v2.3.0
- Update the close message (it closes the issue after 30 days but was mentioning 5 days in the issue comment)